### PR TITLE
Review and polish lakebridge-workshop READMEs

### DIFF
--- a/lakebridge-workshop/README.md
+++ b/lakebridge-workshop/README.md
@@ -1,6 +1,6 @@
 # Lakebridge Workshop
 
-Databricks Labs [Lakebridge](https://databrickslabs.github.io/lakebridge/) を実際に動かして、データウェアハウス / ETL システムから Databricks への移行を体験するハンズオンです。
+Databricks Labs [Lakebridge](https://databrickslabs.github.io/lakebridge/) を実際に動かして、データウェアハウス / ETL システムから Databricks への移行を体験するハンズオン。
 
 ## ゴール
 
@@ -12,7 +12,7 @@ Lakebridge の主要機能 (Analyzer / Transpile / Reconcile) を手を動かし
 |---|---|
 | [datastage/](datastage/) | IBM DataStage ジョブの XML エクスポートを Analyzer + BladeBridge で PySpark Notebook に変換 |
 | [reconcile/](reconcile/) | 移行前後のテーブル差分検証 (Databricks 内のテーブル同士、ソースシステム不要) |
-| [synapse/](synapse/) | Azure Synapse Analytics (Dedicated SQL Pool) の T-SQL コードを Analyzer + 3 種 Transpiler (BladeBridge / Morpheus / Switch) で変換、特徴を比較 |
+| [synapse/](synapse/) | Azure Synapse Analytics (Dedicated SQL Pool) の T-SQL コードを Analyzer + 3 種 Converter (BladeBridge / Morpheus / Switch) で変換、特徴を比較 |
 
 推奨順序は **Synapse → Reconcile → DataStage** だが、各シナリオは独立しているので、興味のあるものから着手しても構わない。
 
@@ -25,9 +25,9 @@ Lakebridge の主要機能 (Analyzer / Transpile / Reconcile) を手を動かし
 - **Unity Catalog** 有効化 (全シナリオ)
 - **Serverless SQL Warehouse** が使える (Transpile (BladeBridge) の出力 SQL 検証、Reconcile 側の source/target 参照で利用)
 - **Foundation Model API** (Claude Sonnet 系) の `Can Query` 権限 (Switch で利用)
-- **ジョブクラスタを起動できる** こと (Reconcile Job は serverless 非対応で、実行時に classic クラスタを自動起動する)
+- **ジョブクラスタを起動できる** こと (Reconcile Job は既定ではクラシックのジョブクラスタを利用する)
 
-### 1. ローカル CLI インストール
+### 1. Databricks CLI のインストール
 
 Databricks CLI をインストールする。OS 別の手順は [公式ドキュメント (日本語)](https://docs.databricks.com/aws/ja/dev-tools/cli/install) を参照。
 
@@ -41,19 +41,19 @@ databricks --version
 
 ### 2. Databricks プロファイル設定
 
-ワークスペースのホスト URL は Cloud によって形式が違う:
+ワークスペースのホスト URL はクラウドによって形式が異なる:
 
 - AWS: `https://<workspace-id>.cloud.databricks.com`
 - Azure: `https://adb-<workspace-id>.<suffix>.azuredatabricks.net`
 - GCP: `https://<workspace-id>.gcp.databricks.com`
 
-実際の値は Databricks コンソールで確認。以下、自分のプロファイル名を `<your-profile>` と置く (任意の名前)。
+実際の値は Databricks コンソールで確認する。以下、自分のプロファイル名を `<your-profile>` とする (任意の名前で OK)。
 
 ```bash
 databricks auth login --host <your-workspace-host> --profile <your-profile>
 ```
 
-ブラウザが開くので OAuth でログイン。以降のコマンドはこの `<your-profile>` を指定して実行する。
+ブラウザが開くので OAuth でログインする。以降のコマンドはこの `<your-profile>` を指定して実行する。
 
 疎通確認:
 
@@ -95,9 +95,9 @@ databricks labs lakebridge --help
 
 `analyze / transpile / llm-transpile / install-transpile / describe-transpile / configure-reconcile / reconcile / aggregates-reconcile` などが並んでいれば OK。
 
-### 4. Transpiler プラグインのインストール
+### 4. Converter プラグインのインストール
 
-Lakebridge の Transpiler 3 種 (BladeBridge / Morpheus / Switch) をまとめてインストールする。**`--include-llm-transpiler true` フラグを付けないと Switch (LLM ベース) は入らない**。
+Lakebridge の Converter 3 種 (BladeBridge / Morpheus / Switch) をまとめてインストールする。**`--include-llm-transpiler true` フラグを付けないと Switch (LLM ベース) はインストールされない**点に留意が必要。
 
 ```bash
 databricks labs lakebridge install-transpile --include-llm-transpiler true --profile <your-profile>
@@ -111,7 +111,7 @@ databricks labs lakebridge describe-transpile --profile <your-profile>
 
 出力に `Bladebridge` と `Morpheus` が並んでいれば OK。
 
-> **Switch は `describe-transpile` には出ない**。Switch は workspace 側に Job + Notebook としてデプロイされる pluggable transpiler で、BladeBridge / Morpheus とはアーキテクチャが違う。`llm-transpile` コマンドで利用する。
+> **Switch は `describe-transpile` には出ない**。Switch は BladeBridge / Morpheus とはアーキテクチャが異なり、Databricks ワークスペースに Job + Notebook としてデプロイされる。`llm-transpile` コマンドで利用する。
 
 ### 5. Reconcile 設定
 
@@ -119,7 +119,7 @@ databricks labs lakebridge describe-transpile --profile <your-profile>
 databricks labs lakebridge configure-reconcile --profile <your-profile>
 ```
 
-対話プロンプトが 9 段階続く。主な入力ポイント:
+対話プロンプトが 9 項目続く。主な入力ポイント:
 
 | 項目 | 入力 |
 |---|---|
@@ -168,10 +168,10 @@ cd databricks-japan-bootcamp/lakebridge-workshop
 
 - **原因**: `~/.databrickscfg` 内に**同じ host を指すプロファイルが複数**あり、Lakebridge 内部の host 解決が衝突する。`--profile` は外側の CLI にしか効かず、内部の SDK 呼び出しは host マッチで profile を引くため衝突を回避できない。
 
-- **対処**: ワークショップ用 host に match するプロファイルが 1 つだけになるように `~/.databrickscfg` を整理する (重複プロファイルを削除するか、`host` を微妙に変えて衝突を回避する)。
+- **対処**: ワークショップ用 host に一致するプロファイルが 1 つだけになるように `~/.databrickscfg` を整理する (重複プロファイルを削除するか、`host` を微妙に変えて衝突を回避する)。
 
 ## 参考
 
 - Lakebridge 公式ドキュメント: https://databrickslabs.github.io/lakebridge/
 - Switch (Lakebridge の pluggable transpiler): https://databrickslabs.github.io/lakebridge/docs/transpile/pluggable_transpilers/switch/
-- `databricks labs lakebridge describe-transpile` で利用可能な transpiler と対応ソースを常に確認できる (Switch は除く)
+- `databricks labs lakebridge describe-transpile` で利用可能な Converter と対応ソースを常に確認できる (Switch は除く)

--- a/lakebridge-workshop/datastage/README.md
+++ b/lakebridge-workshop/datastage/README.md
@@ -59,9 +59,9 @@ databricks labs lakebridge analyze \
 
 ---
 
-## Transpile: BladeBridge (PySpark Notebook)
+## BladeBridge (PySpark Notebook)
 
-DataStage に対応する transpiler は BladeBridge のみなので、**`Select the transpiler:` プロンプトは出ない** (自動で BladeBridge が選ばれる)。
+DataStage に対応する Converter は BladeBridge のみなので、**`Select the transpiler:` プロンプトは出ない** (自動で BladeBridge が選ばれる)。
 
 ### 実行
 
@@ -85,7 +85,7 @@ out/bladebridge/
 └── databricks_conversion_supplements.py  # 共通ユーティリティ (column renaming 等)
 ```
 
-**変換サマリは stdout の 1 行テーブル** (`total_files_processed / parsing_error_count / validation_error_count / generation_error_count / ...`) のみで、別 report や error log ファイルは出力されない。
+**変換サマリは stdout の 1 行テーブル** (`total_files_processed / parsing_error_count / validation_error_count / generation_error_count / ...`) のみで、別のレポートやエラーログファイルは出力されない。
 
 ### ローカルで中身を眺める
 

--- a/lakebridge-workshop/reconcile/README.md
+++ b/lakebridge-workshop/reconcile/README.md
@@ -4,13 +4,13 @@ Reconcile は**移行前後のデータが一致しているか**を機械的に
 
 本 Lab では、外部のソースシステムを用意せず、Databricks 内に source / target の 2 テーブルを作って**差分検出の挙動だけ**を押さえる。
 
-> 既定では、Reconcile Job は serverless 非対応で、実行のたびにジョブクラスタ (classic、2-10 worker) が自動起動する。**クラスタ起動込みで初回は 5〜15 分**程度を見ておく (起動済みクラスタを使い回す手順は後述)。
+> 既定では、Reconcile Job はサーバーレス非対応で、実行のたびにジョブクラスタ (クラシック、2-10 worker) が自動起動する。**クラスタ起動込みで初回は 5〜15 分**程度を見ておく (起動済みクラスタを使い回す手順は後述)。
 
 ## 手順
 
 ### 1. ワークスペース上の Lakebridge 構成を確認
 
-`configure-reconcile` を既に済ませている前提で、このタイミングのワークスペースには以下の構成でファイルが置かれている:
+`configure-reconcile` を既に済ませている前提で、この時点でのワークスペースには以下の構成でファイルが置かれている:
 
 ```
 /Users/<your-email>/.lakebridge/
@@ -78,7 +78,7 @@ version: 1
 
 **手順:**
 
-1. このリポの `config/recon_tables.json` をテンプレとして使う (テーブル構成を変えたい場合は編集)
+1. 本リポジトリの `config/recon_tables.json` をテンプレートとして使う (テーブル構成を変えたい場合は編集)
 2. Databricks ワークスペース UI で `/Users/<your-email>/.lakebridge/` を開く
 3. `config/recon_tables.json` を上記 UI にドラッグ & ドロップで import し、ファイル名を命名規則に沿って変更する (例: `recon_config_databricks_<your_catalog>_all.json`)
 
@@ -90,9 +90,9 @@ databricks labs lakebridge reconcile --profile <your-profile>
 
 `reconcile` コマンドに `--config-file` / `--report-type` などのフラグは**無い** (`reconcile.yml` と配置済み JSON を参照する)。最後に Job URL をブラウザで開くか聞かれる。`yes` で Job 画面が開く、`no` で CLI 側に戻る (どちらを選んでも結果には影響しない)。
 
-Job が Databricks Job として走り、ジョブクラスタの起動込みで**初回は 5〜15 分**ほどで完了する。終了後、`configure-reconcile` で指定した metadata catalog/schema (既定 `remorph.reconcile`) 配下の 6 テーブルに結果が書き込まれる。
+Job が Databricks Job として実行され、ジョブクラスタの起動込みで**初回は 5〜15 分**ほどで完了する。終了後、`configure-reconcile` で指定した metadata catalog/schema (既定 `remorph.reconcile`) 配下の 6 テーブルに結果が書き込まれる。
 
-> **Tips**: 既定では Reconciliation Runner Job は実行のたびに classic new_cluster を起動するが、Databricks Jobs UI からジョブのタスクを「**既存の汎用クラスタ (All-purpose Cluster)**」に切り替えると、起動済みのクラスタを使い回せる。クラスタ起動待ちがなくなり、2 回目以降は 2 分程度で完了する。Reconcile を素早く繰り返したいときに便利。
+> **Tips**: 既定では Reconciliation Runner Job は実行のたびにクラシックの new_cluster を起動するが、Databricks Jobs UI からジョブのタスクを「**既存の汎用クラスタ (All-purpose Cluster)**」に切り替えると、起動済みのクラスタを使い回せる。クラスタ起動待ちがなくなり、2 回目以降は 2 分程度で完了する。Reconcile を素早く繰り返したいときに便利。
 
 ### 5. レポートの確認
 
@@ -152,7 +152,7 @@ ORDER BY recon_type;
 
 - Reconcile は**移行前後のテーブルが本当に一致しているか**を機械的に確認するための標準ツール
 - source/target を両方 Databricks 内に置けるほか (本 Lab の構成)、「移行後のテーブル同士」の整合性チェックにも使える
-- クロスシステム比較 (例: source = Synapse, target = Databricks) の場合、現状は Reconcile 側から外部システムに JDBC で直接接続する構成になっているため **classic クラスタ前提**。Foreign Catalog (Federation) 経由でソースを Unity Catalog から読めるようにする拡張は [lakebridge#2367](https://github.com/databrickslabs/lakebridge/pull/2367) で進行中 (現状は PR レビュー中、マージ後に利用可能)
+- クロスシステム比較 (例: source = Synapse, target = Databricks) の場合、現状は Reconcile 側から外部システムに JDBC で直接接続する構成になっているため**クラシッククラスタ前提**。Foreign Catalog (Federation) 経由でソースを Unity Catalog から読めるようにする拡張は [lakebridge#2367](https://github.com/databrickslabs/lakebridge/pull/2367) で進行中 (現状は PR レビュー中、マージ後に利用可能)
 
 ### レポートタイプの切り替え (補足)
 
@@ -170,7 +170,7 @@ ORDER BY recon_type;
 本 Lab では CLI (`databricks labs lakebridge reconcile`) + JSON ファイルの組み合わせで実行しているが、もう 1 つ**公式サポートされた方法**として、Notebook 内で Python API を直接呼ぶルートがある。
 
 - JSON ファイル不要 (config は Python オブジェクト `ReconcileConfig` / `TableRecon` で組み立てる)
-- Notebook のアタッチ先コンピュートで走る (Job を別途起動しない)
+- Notebook のアタッチ先コンピュートで実行される (Job を別途起動しない)
 - 詳細: 公式 Docs [Running Reconcile on Notebook](https://databrickslabs.github.io/lakebridge/docs/reconcile/recon_notebook/)
 
 CLI 方式と Notebook 方式は用途で使い分けると良い: 定型的な再実行やスケジュール実行には CLI 方式、config を柔軟に組み立てて試行錯誤したい場面には Notebook 方式。
@@ -192,5 +192,5 @@ CLI 方式と Notebook 方式は用途で使い分けると良い: 定型的な�
 ### Job が 10 分以上 RUNNING のまま
 
 - **問題**: Reconcile Job が長時間 `RUNNING` のまま終わらない。
-- **原因**: Reconcile Job は classic new_cluster を自動起動する (serverless 非対応)。クラスタ起動 + ライブラリインストールで数分、ピーク時はクラスタ空き待ちでさらに数分追加される。
-- **対処**: Job URL を UI で開き、cluster の起動状態を確認する。通常は 5〜15 分程度で完了する。
+- **原因**: Reconcile Job はクラシックの new_cluster を自動起動する (サーバーレス非対応)。クラスタ起動 + ライブラリインストールで数分、ピーク時はクラスタ空き待ちでさらに数分追加される。
+- **対処**: Job URL を UI で開き、クラスタの起動状態を確認する。通常は 5〜15 分程度で完了する。

--- a/lakebridge-workshop/synapse/README.md
+++ b/lakebridge-workshop/synapse/README.md
@@ -74,17 +74,17 @@ databricks labs lakebridge analyze \
 - ストアド例 1 (`mssql_example1_multi_statement_transformation.sql`): **LOW**
 - ストアド例 2 (`mssql_example2_stored_procedure.sql`): **MEDIUM** → Switch (LLM) 候補
 
-まずは全ファイルをルールベース (BladeBridge / Morpheus) で回してみて、パース失敗や変換残差が目立つものを Switch (LLM) に切り替える、というのが基本的な進め方。
+まずは全ファイルをルールベース (BladeBridge / Morpheus) で回してみて、パース失敗や未変換箇所が目立つものを Switch (LLM) に切り替える、というのが基本的な進め方。
 
 ---
 
-## Transpile: BladeBridge
+## BladeBridge
 
-BladeBridge は **正規表現ベースのルールベース**トランスパイラ (Perl + JSON config)。**幅広いソース** (Synapse / Teradata / Oracle / MSSQL / Netezza / DataStage / SSIS など) に対応し、`--overrides-file` / `--transpiler-config-path` で書換えルールをカスタマイズできる点が特徴。対応ソースの全体は `databricks labs lakebridge describe-transpile` の出力で確認できる。
+BladeBridge は**正規表現ベース**の変換機能。**幅広いソース** (Synapse / Teradata / Oracle / MSSQL / Netezza / DataStage / SSIS など) に対応し、`--overrides-file` / `--transpiler-config-path` で書き換えルールをカスタマイズできる点が特徴。対応ソースの一覧は `databricks labs lakebridge describe-transpile` の出力で確認できる。
 
 ### 実行
 
-Synapse は BladeBridge と Morpheus の両方が対応しているため、`--transpiler-config-path` で BladeBridge を明示指定する:
+Synapse には BladeBridge と Morpheus の両方で対応しているため、`--transpiler-config-path` で BladeBridge を明示指定する:
 
 ```bash
 mkdir -p out/bladebridge
@@ -109,7 +109,7 @@ out/bladebridge/
     └── mssql_example2_stored_procedure.sql
 ```
 
-**別ファイルとしての変換レポートやエラーログは生成されない。** 変換結果のサマリは標準出力に 1 行テーブル (`total_files_processed / parsing_error_count / validation_error_count / generation_error_count / ...`) として表示されるのみ。
+**変換レポートやエラーログが別ファイルとして生成されることはない。** 変換結果のサマリは標準出力に 1 行テーブル (`total_files_processed / parsing_error_count / validation_error_count / generation_error_count / ...`) として表示されるのみ。
 
 ### Validator による Exception wrapping
 
@@ -153,7 +153,7 @@ LastUpdatedAt   timestamp    NOT NULL DEFAULT current_timestamp();,
 ### 学習ポイント
 
 - BladeBridge は**幅広いソースに対応**している
-- 変換結果がそのまま動くことも多いが、**細かいパッチ** (余計な `;` など) が残るケースが一定ある
+- 変換結果がそのまま動くことも多いが、**細かいパッチ** (余計な `;` など) が残るケースが一定数ある
 - Synapse の T-SQL 固有構文 (`PARTITION ... RANGE RIGHT FOR VALUES`、`LineAmount AS (...) PERSISTED` 計算列) は書換えを試みた上で、validator に弾かれるケースがある
 
 ### 変換ルールのカスタマイズ (補足)
@@ -163,13 +163,13 @@ BladeBridge は 2 通りのカスタマイズ手段を提供する:
 - `--overrides-file`: 既存ルール集に `line_subst` / `block_subst` の regex を**追加**する (軽い補正向け)
 - `--transpiler-config-path`: 変換ルール集を**まるごと別のものに差し替える** (重い改造向け)
 
-カスタマイズのやりやすさはソースによって差がある。**Teradata / Oracle / Netezza / Redshift** などは `--overrides-file` でルールを足す方法が有効に機能する。**Synapse / mssql / snowflake** はルール集の構造上 `--overrides-file` が期待どおり動かないことがあるため、変換精度を上げたい場合は Morpheus を主軸にして出力の `FIXME` を手動またはカスタムの後処理スクリプトを作成して機械的に直す、意味を汲んだ書き換えが必要な部分は Switch (LLM) に送る、という流れのほうが実践的。
+カスタマイズのしやすさはソースによって差がある。**Teradata / Oracle / Netezza / Redshift** などは `--overrides-file` でルールを足す方法が有効に機能する。**Synapse / mssql / snowflake** はルール集の構造上 `--overrides-file` が期待どおり動かないことがあるため、変換精度を上げたい場合は Morpheus を主軸にし、出力の `FIXME` を手動修正やカスタムスクリプトで対処する。意味を汲んだ書き換えが必要な箇所は Switch (LLM) に回す、という流れが実践的。
 
 ---
 
-## Transpile: Morpheus
+## Morpheus
 
-Morpheus は Databricks Labs が開発するルールベーストランスパイラ。ANTLR パーサーで SQL を構造的に解析し、**元の SQL 構文を保持しつつ `FIXME` コメントで未対応箇所を明示**するスタイル。現時点の対応方言は mssql / snowflake / synapse (今後拡張予定)。BladeBridge より対応方言は狭い。Databricks Labs が直接開発しているため改善の反映が速く、変換の実行速度も BladeBridge を上回る。
+Morpheus は Databricks Labs が開発するルールベースの変換機能。ANTLR パーサーで SQL を構造的に解析し、**元の SQL 構文を保持しつつ `FIXME` コメントで未対応箇所を明示**するスタイル。現時点の対応方言は mssql / snowflake / synapse (今後拡張予定)。BladeBridge より対応方言は狭い。Databricks Labs が直接開発しているため改善の反映が速く、変換の実行速度も BladeBridge を上回る。
 
 ### 実行
 
@@ -220,7 +220,7 @@ CREATE
 
 ### パース失敗の例 (`04_orders.sql`)
 
-Morpheus は ANTLR パーサーで SQL を構造解析するため、T-SQL 固有構文を読み切れないと**ファイル全体がパース失敗**となり、Exception ブロックで wrap された状態で出力される。たとえば `04_orders.sql` の `PARTITION ... RANGE RIGHT FOR VALUES` は Morpheus のパーサー規則にないため `PARSE_SYNTAX_ERROR` となり、ほぼ原文のまま Exception でくるまれる。
+Morpheus は ANTLR パーサーで SQL を構造解析するため、T-SQL 固有構文を解析しきれないと**ファイル全体がパース失敗**となり、Exception ブロックで囲まれた状態で出力される。たとえば `04_orders.sql` の `PARTITION ... RANGE RIGHT FOR VALUES` は Morpheus のパーサー規則にないため `PARSE_SYNTAX_ERROR` となり、ほぼ原文のまま Exception でくるまれる。
 
 一方、BladeBridge は正規表現ベースのため同じファイルをパターン置換で書き換えを試み、`PARTITION` 句を削除/改変して最終的に構文的に通る SQL を出力する (ただし意味が保たれるとは限らない)。両者の差は、Exception ブロックの有無と `FIXME` コメントの位置で一目で分かる。
 
@@ -229,15 +229,15 @@ Morpheus は ANTLR パーサーで SQL を構造解析するため、T-SQL 固�
 - **Morpheus の強み**: 速度、T-SQL 構文保持 (原文対比でレビューしやすい)、Databricks Labs が継続的に改善している
 - **Morpheus の弱み**: T-SQL 固有構文 (例: `PARTITION ... RANGE RIGHT FOR VALUES`) でパース失敗するとファイル単位で Exception wrap されるため、その部分は手動で書き換える必要がある
 - **使い分けは品質を見て決める**のが実務的。両方実行して diff を取るのが最速
-- **Morpheus は現状、カスタマイズ口が公開されていない** (ANTLR + JAR 内蔵)。BladeBridge の `--overrides-file` のような補正機構は無い
+- **Morpheus は現状、カスタマイズ手段が公開されていない** (ANTLR + JAR 内蔵)。BladeBridge の `--overrides-file` のような補正機構は無い
 
 ---
 
-## Transpile: Switch
+## Switch
 
-Switch は **LLM ベース**のトランスパイラで、**Lakebridge の pluggable transpiler の 1 つ**として提供される。Databricks Job として workspace 上で走り、**既定では Python Notebook** を出力する (BladeBridge / Morpheus は `.sql` ファイル)。複雑なストアドプロシージャの変換や、構文の意味を汲んだ書き換え (計算列の型推論など) を得意とする。
+Switch は **LLM ベース**の変換機能で、**Lakebridge の pluggable transpiler の 1 つ**として提供される。Databricks Job として Workspace 上で実行され、**既定では Python Notebook** を出力する (BladeBridge / Morpheus は `.sql` ファイル)。複雑なストアドプロシージャの変換や、構文の意味を汲んだ書き換え (計算列の型推論など) を得意とする。
 
-利用モデルは Databricks の **基盤モデル API** の任意モデル、および Model Serving 上の外部モデルも選択可能。出力形式も設定で `.sql` / `.py` などに切り替えられる。
+利用するモデルは Databricks の**基盤モデル API** の任意のモデルを選択できる。出力形式も設定で `.sql` / `.py` などに切り替えられる。
 
 ### 事前準備: 出力サブディレクトリを作成
 
@@ -259,7 +259,7 @@ databricks labs lakebridge llm-transpile \
   --profile <your-profile>
 ```
 
-対話プロンプトが 4 段階続く:
+対話プロンプトが 4 項目続く:
 
 | 項目 | 推奨 | 既定 |
 |---|---|---|
@@ -275,7 +275,7 @@ databricks labs lakebridge llm-transpile \
 | パラメータ | 意味 |
 |---|---|
 | `--input-source` | 手元の入力ディレクトリ (自動で Unity Catalog Volume にアップロード) |
-| `--output-ws-folder` | Databricks Workspace 上の出力パス (必ず　`/Workspace/` で始まる必要がある) |
+| `--output-ws-folder` | Databricks Workspace 上の出力パス (必ず `/Workspace/` で始まる必要がある) |
 | `--source-dialect` | `synapse` |
 | `--accept-terms` | LLM ベース変換の利用規約に同意 (`true`) |
 
@@ -290,7 +290,7 @@ INFO [d.l.l.transpiler.switch_runner] Switch LLM transpilation job started: http
 
 ### Job の進捗を監視
 
-返された Job URL を開いて Switch Job の run を監視。LLM が並列呼び出しするため所要時間はファイル本数に比例しない。本 Lab 程度なら数分のオーダーで完了することが多い。
+返された Job URL を開いて Switch Job の run を監視。LLM が並列に呼び出されるため、所要時間はファイル数に比例して増えない。本 Lab 程度なら数分のオーダーで完了することが多い。
 
 Switch は workspace 内 **結果テーブル** (`<catalog>.switch.lakebridge_switch_<timestamp>_<suffix>`) にも全ファイルの変換結果を記録しており、そちらを SELECT すれば進捗/エラーも確認できる。結果テーブルのスキーマは公式ドキュメント [Customizing Switch](https://databrickslabs.github.io/lakebridge/docs/transpile/pluggable_transpilers/switch/customizing_switch/) を参照。
 
@@ -316,7 +316,7 @@ CREATE TABLE IF NOT EXISTS dbo.order_items (
 """)
 ```
 
-**Switch の真価**: `05_order_items.sql` の `LineAmount AS (Quantity * UnitPrice - DiscountAmount) PERSISTED` (T-SQL 計算列、型指定なし) を **`DECIMAL(18,2) GENERATED ALWAYS AS (...)` に型推論込みで変換**。これは BladeBridge / Morpheus の regex では書けない、構文の意味を汲んだ書き換え。
+**Switch の真価**: `05_order_items.sql` の `LineAmount AS (Quantity * UnitPrice - DiscountAmount) PERSISTED` (T-SQL 計算列、型指定なし) を **`DECIMAL(18,2) GENERATED ALWAYS AS (...)` に型推論込みで変換**。これは BladeBridge / Morpheus のルールベースの変換では対応困難な、構文の意味を汲んだ書き換え。
 
 ### 学習ポイント
 

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/01_customers.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/01_customers.sql
@@ -1,11 +1,26 @@
 -------------- Exception Start-------------------
 /*
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near end of input. SQLSTATE: 42601 (line 2, pos 0)
+[PARSE_SYNTAX_ERROR] Syntax error at or near ';': missing ')'. SQLSTATE: 42601 (line 12, pos 69)
 
 == SQL ==
-EXPLAIN 
-^^^
+EXPLAIN -- Synapse Dedicated SQL Pool: customers table
+-- HASH distribution on CustomerID for even distribution across 60 compute nodes
+
+CREATE OR REPLACE TABLE dbo.customers
+(
+    CustomerID      BIGINT          NOT NULL,
+    CustomerName STRING   NOT NULL,
+    Email STRING,
+    PhoneNumber STRING,
+    BirthDate       DATE            ,
+    Gender          STRING,
+    RegisteredAt    timestamp    NOT NULL DEFAULT current_timestamp();,
+---------------------------------------------------------------------^^^
+    LastUpdatedAt   timestamp    NOT NULL DEFAULT current_timestamp();,
+    IsActive        BOOLEAN             NOT NULL DEFAULT 1
+)
+;
 
 */
 

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/02_products.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/02_products.sql
@@ -1,12 +1,14 @@
--------------- Exception Start-------------------
-/*
+-- Synapse Dedicated SQL Pool: products table
+-- Small master table; replicate across all distributions
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near end of input. SQLSTATE: 42601 (line 2, pos 0)
-
-== SQL ==
-EXPLAIN 
-^^^
-
-*/
-
- ---------------Exception End --------------------
+CREATE OR REPLACE TABLE dbo.products
+(
+    ProductID       INT             NOT NULL,
+    ProductName STRING   NOT NULL,
+    CategoryCode STRING     NOT NULL,
+    UnitPrice       DECIMAL(19,4)           NOT NULL,
+    Barcode STRING,
+    LaunchedAt      DATE            ,
+    DiscontinuedAt  DATE            
+)
+;

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/03_stores.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/03_stores.sql
@@ -1,12 +1,12 @@
--------------- Exception Start-------------------
-/*
+-- Synapse Dedicated SQL Pool: stores table
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near end of input. SQLSTATE: 42601 (line 2, pos 0)
-
-== SQL ==
-EXPLAIN 
-^^^
-
-*/
-
- ---------------Exception End --------------------
+CREATE OR REPLACE TABLE dbo.stores
+(
+    StoreID         INT             NOT NULL,
+    StoreName STRING   NOT NULL,
+    RegionCode STRING     NOT NULL,
+    PrefectureCode STRING      NOT NULL,
+    OpenedAt        DATE            NOT NULL,
+    ClosedAt        DATE            
+)
+;

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/04_orders.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/04_orders.sql
@@ -1,11 +1,24 @@
 -------------- Exception Start-------------------
 /*
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near end of input. SQLSTATE: 42601 (line 2, pos 0)
+[PARSE_SYNTAX_ERROR] Syntax error at or near ';': extra input ';'. SQLSTATE: 42601 (line 13, pos 69)
 
 == SQL ==
-EXPLAIN 
-^^^
+EXPLAIN -- Synapse Dedicated SQL Pool: orders table
+-- Large fact table partitioned by OrderDate (monthly) and hashed on CustomerID
+
+CREATE OR REPLACE TABLE dbo.orders
+(
+    OrderID         BIGINT          NOT NULL,
+    CustomerID      BIGINT          NOT NULL,
+    StoreID         INT             NOT NULL,
+    OrderDate       DATE            NOT NULL,
+    OrderStatus STRING     NOT NULL,
+    TotalAmount     DECIMAL(18,2)   NOT NULL,
+    TaxAmount       DECIMAL(18,2)   NOT NULL,
+    CreatedAt       timestamp    NOT NULL DEFAULT current_timestamp();)
+---------------------------------------------------------------------^^^
+;
 
 */
 

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/05_order_items.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/ddl/05_order_items.sql
@@ -1,11 +1,24 @@
 -------------- Exception Start-------------------
 /*
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near end of input. SQLSTATE: 42601 (line 2, pos 0)
+[PARSE_SYNTAX_ERROR] Syntax error at or near '(': missing ')'. SQLSTATE: 42601 (line 12, pos 23)
 
 == SQL ==
-EXPLAIN 
-^^^
+EXPLAIN -- Synapse Dedicated SQL Pool: order_items table
+-- Hash on OrderID to co-locate with orders during joins
+
+CREATE OR REPLACE TABLE dbo.order_items
+(
+    OrderID         BIGINT          NOT NULL,
+    LineNumber      INT             NOT NULL,
+    ProductID       INT             NOT NULL,
+    Quantity        INT             NOT NULL,
+    UnitPrice       DECIMAL(18,2)   NOT NULL,
+    DiscountAmount  DECIMAL(18,2)   NOT NULL DEFAULT 0,
+    LineAmount      AS (Quantity * UnitPrice - DiscountAmount) PERSISTED
+-----------------------^^^
+)
+;
 
 */
 

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/stored_procs/mssql_example1_multi_statement_transformation.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/stored_procs/mssql_example1_multi_statement_transformation.sql
@@ -1,11 +1,71 @@
 -------------- Exception Start-------------------
 /*
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near end of input. SQLSTATE: 42601 (line 2, pos 0)
+[PARSE_SYNTAX_ERROR] Syntax error at or near ';': extra input ';'. SQLSTATE: 42601 (line 11, pos 51)
 
 == SQL ==
-EXPLAIN 
-^^^
+EXPLAIN -- ==========================================
+-- T-SQL EXAMPLE #1: Multi-Statement Data Transformation
+-- ==========================================
+
+-- Create a table for product data
+
+CREATE OR REPLACE TABLE Products (
+    ProductID INT,
+    ProductName STRING,
+    Price DECIMAL(19,4),
+    CreatedAt TIMESTAMP DEFAULT current_timestamp(););
+---------------------------------------------------^^^
+-- Insert some sample products
+
+INSERT INTO Products 
+(ProductID, ProductName, Price)
+VALUES
+    (101, 'Widget A', 12.50),
+    (102, 'Widget B', 19.99),
+    (103, 'Widget C', 29.75);
+-- Create a temporary table to capture discounted items
+
+CREATE TEMPORARY TABLE TEMP_TABLE_Discounts (
+    ProductID INT,
+    DiscountRate DOUBLE
+);
+-- Insert discount rates
+
+INSERT INTO TEMP_TABLE_Discounts 
+(ProductID, DiscountRate)
+VALUES
+    (101, 0.10),
+    (103, 0.25);
+-- Update product prices where a discount is applicable
+-- (T-SQL allows an UPDATE with a FROM clause)
+
+MERGE INTO Products p_TGT
+USING (
+SELECT * 
+FROM Products p
+INNER JOIN TEMP_TABLE_Discounts d ON p.ProductID = d.ProductID
+)
+ON 
+COALESCE(p.Price::string,'__NULL__') = COALESCE(p_TGT.Price::string,'__NULL__') AND 
+COALESCE(p.ProductID::string,'__NULL__') = COALESCE(p_TGT.ProductID::string,'__NULL__')
+WHEN MATCHED THEN UPDATE SET
+Price = p.Price * ( 1 - d.DiscountRate );
+-- Demonstrate a conditional DELETE
+-- Suppose we delete any product older than 7 days with no discounts
+-- (Pretend we have some reason to prune old, non-discounted items)
+
+DELETE p
+FROM Products p
+WHERE p.CreatedAt < DATEADD(DAY, -7, current_timestamp())
+  AND p.ProductID NOT IN (SELECT ProductID FROM TEMP_TABLE_Discounts);
+-- Final SELECT to confirm changes
+
+SELECT * FROM Products;
+-- Clean up permanent table only
+-- DROP TABLE IF EXISTS #Discounts; -- Temp tables are automatically dropped at the end of the session
+
+DROP TABLE IF EXISTS Products;
 
 */
 

--- a/lakebridge-workshop/synapse/_reference_output/bladebridge/stored_procs/mssql_example2_stored_procedure.sql
+++ b/lakebridge-workshop/synapse/_reference_output/bladebridge/stored_procs/mssql_example2_stored_procedure.sql
@@ -1,121 +1,135 @@
 -------------- Exception Start-------------------
 /*
 
-[PARSE_SYNTAX_ERROR] Syntax error at or near '['. SQLSTATE: 42601 (line 5, pos 17)
+[PARSE_SYNTAX_ERROR] Syntax error at or near ';'. SQLSTATE: 42601 (line 7, pos 35)
 
 == SQL ==
 EXPLAIN -- ==========================================
 -- T-SQL EXAMPLE #2: Stored Procedure with Outlier Checking
 -- ==========================================
 
-CREATE PROCEDURE [dbo].[DEMO_FORECAST_OUTLIER_CHECK_UPDATE]
------------------^^^
-    @SchemaName         NVARCHAR(128),
-    @OutlierMultiplier  DECIMAL(5,2) = 1.30
+CREATE OR REPLACE PROCEDURE `dbo`.`DEMO_FORECAST_OUTLIER_CHECK_UPDATE`(
+IN V_SchemaName STRING,
+IN V_OutlierMultiplier DECIMAL(5,2); DEFAULT 1.30)
+-----------------------------------^^^
+LANGUAGE SQL
+SQL SECURITY INVOKER
 AS
-BEGIN
-    -- Variable declarations
-    DECLARE @Result           INT           = 0;
-    DECLARE @ErrorMsg         NVARCHAR(MAX);
-    DECLARE @CurrentDate      DATE;
-    DECLARE @ErrorProcName    NVARCHAR(128) = OBJECT_NAME(@@PROCID);
 
-    -- Create a temporary table to store outlier thresholds
-    CREATE TABLE #TEMP_OUTLIER_INFO (
-          LocationId       NVARCHAR(10),
+BEGIN
+
+    
+DECLARE VARIABLE V_Result           INT           ;
+
+DECLARE VARIABLE V_ErrorMsg STRING;
+DECLARE VARIABLE V_CurrentDate      DATE;
+DECLARE VARIABLE V_ErrorProcName STRING ;
+
+DECLARE VARIABLE V_SQL STRING;
+-- Variable declarations
+
+SET V_Result = 0;
+SET V_ErrorProcName = OBJECT_NAME(V_V_PROCID);
+-- Create a temporary table to store outlier thresholds
+
+CREATE TEMPORARY TABLE TEMP_TABLE_TEMP_OUTLIER_INFO (
+          LocationId STRING,
           OutlierThreshold DECIMAL(8,2)
     );
+DECLARE EXIT HANDLER FOR SQLEXCEPTION
+BEGIN
+GET DIAGNOSTICS CONDITION 1
 
-    BEGIN TRY
-        BEGIN TRAN FORECAST_OUTLIER_CHECK;
+        ;
+SET V_Result = 2;
+SET V_ErrorMsg = MESSAGE_TEXT;
+SELECT('Error: ' || V_ErrorMsg);
+IF (V_V_TRANCOUNT > 0)
+            ;
+ROLLBACK TRAN FORECAST_OUTLIER_CHECK;
+-- Log the error (simplified):
 
-        -- 1) Retrieve current date from a "SystemDateTable" in the given schema
-        DECLARE @SQL NVARCHAR(MAX);
-        SET @SQL = N'
-            SELECT @CurrentDateOut = SystemDate
-            FROM ' + QUOTENAME(@SchemaName) + N'.SystemDateTable;
+call `dbo`.`LogError`(
+            V_ProcName     = V_ErrorProcName,
+            V_ErrorMessage = V_ErrorMsg);
+        -- Re-throw the error
+        SIGNAL SQLSTATE '45000';
+
+END;
+
+TRAN FORECAST_OUTLIER_CHECK;
+-- 1) Retrieve current date from a "SystemDateTable" in the given schema
+
+SET V_SQL = '
+            SELECT V_CurrentDateOut = SystemDate
+            FROM ' || concat('[', V_SchemaName, ']') || '.SystemDateTable;
         ';
+CALL
+            V_SQL,
+            'V_CurrentDateOut DATE ',
+            V_CurrentDateOut = V_CurrentDate ;
+-- 2) Insert outlier thresholds (99th percentile) from "HistoricalDataTable"
 
-        EXEC sp_executesql
-            @SQL,
-            N'@CurrentDateOut DATE OUTPUT',
-            @CurrentDateOut = @CurrentDate OUTPUT;
-
-        -- 2) Insert outlier thresholds (99th percentile) from "HistoricalDataTable"
-        SET @SQL = N'
-            INSERT INTO #TEMP_OUTLIER_INFO (LocationId, OutlierThreshold)
+SET V_SQL = '
+            INSERT INTO TEMP_TABLE_TEMP_OUTLIER_INFO (LocationId, OutlierThreshold)
             SELECT
                 d.LocationId,
-                CONVERT(DECIMAL(8,2),
-                    PERCENTILE_CONT(0.99)
-                    WITHIN GROUP (ORDER BY d.MetricValue)
-                    OVER (PARTITION BY d.LocationId)
-                )
-            FROM ' + QUOTENAME(@SchemaName) + N'.HistoricalDataTable d
-            WHERE CONVERT(DATE, d.TargetDate) >= DATEADD(YEAR, -1, @CurrentDateParam)
+                CAST(PERCENTILE_CONT(0.99)
+WITHIN GROUP (ORDER BY d.MetricValue)
+OVER (PARTITION BY d.LocationId) AS DECIMAL(8,2))
+            FROM ' || concat('[', V_SchemaName, ']') || '.HistoricalDataTable d
+            WHERE CAST(d.TargetDate AS DATE) >= DATEADD(YEAR, -1, V_CurrentDateParam)
         ';
+CALL
+            V_SQL,
+            'V_CurrentDateParam DATE',
+            V_CurrentDateParam = V_CurrentDate;
+-- 3) Save original forecast values above threshold in "ForecastTable"
 
-        EXEC sp_executesql
-            @SQL,
-            N'@CurrentDateParam DATE',
-            @CurrentDateParam = @CurrentDate;
+SET V_SQL = '
+            MERGE INTO ' || concat('[', V_SchemaName, ']') || '.ForecastTable f
+USING (
+SELECT * 
+FROM ' || concat('[', V_SchemaName, ']') || '.ForecastTable f
+INNER JOIN TEMP_TABLE_TEMP_OUTLIER_INFO t ON f.LocationId = t.LocationId
+)
+ON CAST(f.ForecastDate AS DATE) = V_CurrentDateParam AND f.ForecastValue > t.OutlierThreshold * V_Multiplier '; AND 
+COALESCE(f.OriginalForecastValue::string,'__NULL__') = COALESCE(f_TGT.OriginalForecastValue::string,'__NULL__') AND 
+COALESCE(f.ForecastValue::string,'__NULL__') = COALESCE(f_TGT.ForecastValue::string,'__NULL__') AND 
+COALESCE(f.LocationId::string,'__NULL__') = COALESCE(f_TGT.LocationId::string,'__NULL__') AND 
+COALESCE(f.ForecastDate::string,'__NULL__') = COALESCE(f_TGT.ForecastDate::string,'__NULL__')
+WHEN MATCHED THEN UPDATE SET
+OriginalForecastValue = f.ForecastValue;
+CALL
+            V_SQL,
+            'V_CurrentDateParam DATE, V_Multiplier DECIMAL(5,2)',
+            V_CurrentDateParam = V_CurrentDate,
+            V_Multiplier = V_OutlierMultiplier;
+-- 4) Update outlier values to cap them at threshold * multiplier
 
-        -- 3) Save original forecast values above threshold in "ForecastTable"
-        SET @SQL = N'
-            UPDATE f
-            SET f.OriginalForecastValue = f.ForecastValue
-            FROM ' + QUOTENAME(@SchemaName) + N'.ForecastTable f
-            INNER JOIN #TEMP_OUTLIER_INFO t ON f.LocationId = t.LocationId
-            WHERE CONVERT(DATE, f.ForecastDate) = @CurrentDateParam
-              AND f.ForecastValue > t.OutlierThreshold * @Multiplier
-        ';
+SET V_SQL = '
+            MERGE INTO ' || concat('[', V_SchemaName, ']') || '.ForecastTable f
+USING (
+SELECT * 
+FROM ' || concat('[', V_SchemaName, ']') || '.ForecastTable f
+INNER JOIN TEMP_TABLE_TEMP_OUTLIER_INFO t ON f.LocationId = t.LocationId
+)
+ON CAST(f.ForecastDate AS DATE) = V_CurrentDateParam AND f.ForecastValue > t.OutlierThreshold * V_Multiplier '; AND 
+COALESCE(f.ForecastValue::string,'__NULL__') = COALESCE(f_TGT.ForecastValue::string,'__NULL__') AND 
+COALESCE(f.LocationId::string,'__NULL__') = COALESCE(f_TGT.LocationId::string,'__NULL__') AND 
+COALESCE(f.ForecastDate::string,'__NULL__') = COALESCE(f_TGT.ForecastDate::string,'__NULL__')
+WHEN MATCHED THEN UPDATE SET
+ForecastValue = t.OutlierThreshold * V_Multiplier;
+CALL
+            V_SQL,
+            'V_CurrentDateParam DATE, V_Multiplier DECIMAL(5,2)',
+            V_CurrentDateParam = V_CurrentDate,
+            V_Multiplier = V_OutlierMultiplier;
+COMMIT TRAN FORECAST_OUTLIER_CHECK;
+-- DROP TABLE IF EXISTS #TEMP_OUTLIER_INFO; -- Temp tables are automatically dropped at the end of the session
 
-        EXEC sp_executesql
-            @SQL,
-            N'@CurrentDateParam DATE, @Multiplier DECIMAL(5,2)',
-            @CurrentDateParam = @CurrentDate,
-            @Multiplier = @OutlierMultiplier;
-
-        -- 4) Update outlier values to cap them at threshold * multiplier
-        SET @SQL = N'
-            UPDATE f
-            SET f.ForecastValue = t.OutlierThreshold * @Multiplier
-            FROM ' + QUOTENAME(@SchemaName) + N'.ForecastTable f
-            INNER JOIN #TEMP_OUTLIER_INFO t ON f.LocationId = t.LocationId
-            WHERE CONVERT(DATE, f.ForecastDate) = @CurrentDateParam
-              AND f.ForecastValue > t.OutlierThreshold * @Multiplier
-        ';
-
-        EXEC sp_executesql
-            @SQL,
-            N'@CurrentDateParam DATE, @Multiplier DECIMAL(5,2)',
-            @CurrentDateParam = @CurrentDate,
-            @Multiplier = @OutlierMultiplier;
-
-        COMMIT TRAN FORECAST_OUTLIER_CHECK;
-    END TRY
-    BEGIN CATCH
-        SET @Result = 2;
-        SET @ErrorMsg = ERROR_MESSAGE();
-        PRINT('Error: ' + @ErrorMsg);
-
-        IF (@@TRANCOUNT > 0)
-            ROLLBACK TRAN FORECAST_OUTLIER_CHECK;
-
-        -- Log the error (simplified):
-        EXEC [dbo].[LogError]
-            @ProcName     = @ErrorProcName,
-            @ErrorMessage = @ErrorMsg;
-
-        -- Re-throw the error
-        THROW;
-    END CATCH;
-
-    -- DROP TABLE IF EXISTS #TEMP_OUTLIER_INFO; -- Temp tables are automatically dropped at the end of the session
-
-    RETURN @Result;
+RETURN V_Result;
 END;
-GO
 
 */
 


### PR DESCRIPTION
## Summary
- lakebridge-workshop の全 README の日本語を精査し、自然さ・統一感を改善
- BladeBridge reference output を再生成し、README の説明と整合する状態に修正

## 変更内容

### テキスト修正 (4 ファイル)
- **用語統一**: Converter/変換機能の使い分けを整理 (ラベル=Converter、地の文=変換機能)、セクション見出しから `Transpile:` を除去
- **カタカナ統一**: classic→クラシック、serverless→サーバーレス (UI ラベルとコード値は英語のまま)
- **日本語の自然さ**: 体言止め→動詞終止の統一、口語表現の書き言葉化 (`走り`→`実行され`、`カスタマイズ口`→`カスタマイズ手段` 等)
- **不正確な記述の修正**: Morpheus を regex と呼んでいた箇所→ルールベース、主語のねじれ修正、長文の分割
- **その他**: 全角スペース除去、略語の正式化、`デフォルト`→`既定` 統一

### Reference output 再生成 (BladeBridge 7 ファイル)
- 旧出力は全件が同一の `EXPLAIN` エラーの Exception ブロックで、変換結果が確認できない状態だった
- validation 付きで再生成し、README のインライン例と整合する clean/exception の分布に修正:
  - Clean: `02_products.sql`, `03_stores.sql`
  - Exception: `01_customers.sql`, `04_orders.sql`, `05_order_items.sql`, `example1`, `example2`

## Test plan
- [ ] 各 README をブラウザでレンダリングし、表・コードブロック・リンクが崩れていないか確認
- [ ] BladeBridge reference output の clean ファイル (`02_products.sql`) が README のインライン例と整合していることを確認
- [ ] BladeBridge reference output の exception ファイル (`01_customers.sql`) が README の `;` 問題の説明と整合していることを確認

This pull request and its description were written by Isaac.